### PR TITLE
BUGBOT v2: concise persona-driven review analysis

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -1,28 +1,11 @@
 # BUGBOT — mock-publisher-express4
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-## Overview
+> Watches for naming accuracy, authentication flow correctness, and data-state mismatches in this Express publisher service.
 
-**Insufficient review data** — only 1 inline review comment was found across all PRs in this repository. Meaningful pattern analysis requires at least 5 inline comments. No subdirectory-level BUGBOT files have been created.
+## Code Quality
+- **Misleading variable names**: Name variables for their actual state — avoid `signedPayload` before signing has occurred.
 
-## Data Summary
-
-| Metric | Value |
-|--------|-------|
-| PRs analysed | 5 |
-| Inline review comments | 1 |
-| PRs with non-empty review bodies | 0 |
-
-## Single Comment on Record
-
-- **File:** `index.js`
-- **PR:** [#1 — Authentication methods Upgrade](https://github.com/Appcharge/mock-publisher-express4/pull/1#discussion_r1216667847)
-- **Reviewer:** TheKush3
-- **Comment:** "bad naming, the payload is not signed yet" — flagging a misleading variable name (`signedPayload`) used before the signing step had actually occurred.
-- **Category:** Code Quality / Naming
-
-## Action Items
-
-- [ ] Accumulate more PR reviews to enable pattern analysis
-- [ ] Ensure variable names reflect the actual state of data at the point of use (e.g. avoid `signedPayload` before signing)
+## Checklist
+- [ ] Variable names reflect actual data state at point of use
+- [ ] Signing/encoding steps complete before naming result as such
+- [ ] Authentication flow steps are clearly sequenced and named


### PR DESCRIPTION
## BUGBOT v2 — Improved Analysis Files

Replaces the previous verbose BUGBOT.md files with a concise, persona-driven format:
- Short persona block per file declaring what the BUGBOT watches
- One-line bullet rules (no PR quotes, no frequency tables, no historical examples)
- Actionable checklist at the end
- Max 60 lines (root) / 30 lines (subdirectory)

Generated by BUGBOT improve-bugbot.sh